### PR TITLE
fix bugs of softice.ASM, "Execution Timing", and "Guard Pages".

### DIFF
--- a/ASMsrc/guardpage.ASM
+++ b/ASMsrc/guardpage.ASM
@@ -1,0 +1,26 @@
+include 'win32ax.inc'
+
+.code
+
+ start:
+	xor ebx, ebx
+	invoke VirtualAlloc,ebx,1,1000h,40h
+	mov byte [eax], 0c3h
+	push eax
+	xchg ebp, eax
+	invoke VirtualProtect,ebp,1,140h,esp
+	push .exit
+	push dword [fs:ebx]
+	mov [fs:ebx], esp
+	push .being_debugged
+	;execution resumes at being_debugged
+	;if ret instruction is executed
+	jmp ebp
+	.being_debugged:
+		invoke	MessageBox,HWND_DESKTOP,"Debugger Found!",invoke GetCommandLine,MB_OK
+		invoke	ExitProcess, 0
+	.exit:
+		invoke	MessageBox,HWND_DESKTOP,"Debugger Not Found!",invoke GetCommandLine,MB_OK
+		invoke	ExitProcess,0
+
+.end start

--- a/ASMsrc/softice.ASM
+++ b/ASMsrc/softice.ASM
@@ -16,9 +16,10 @@ include 'win32ax.inc'
 
   start:
 	xor	eax, eax
+	push	.exception
 	push	dword [fs:0]
 	mov	[fs:0],esp
-	int1
+	int 1
 	.exception:
 		mov	eax,[esp+0x4]
 		cmp	dword[eax], 0x80000004

--- a/Csrc/fcall_examples/fcall_examples/fcall_examples.cpp
+++ b/Csrc/fcall_examples/fcall_examples/fcall_examples.cpp
@@ -578,7 +578,7 @@ void sGetTickCount() {
 
 	initial = GetTickCount();
 	end = GetTickCount();
-	if ((initial - end) >= 10)
+	if ((end - initial) >= 10)
 		printf("Debugger detected\n");
 	else
 		printf("Debugger not detected\n");
@@ -592,7 +592,7 @@ void stimeGetTime() {
 
 	initial = timeGetTime();
 	end = timeGetTime();
-	if ((initial - end) >= 10)
+	if ((end - initial) >= 10)
 		printf("Debugger detected\n");
 	else
 		printf("Debugger not detected\n");
@@ -608,7 +608,7 @@ void sGetSystemTime() {
 	GetSystemTime(&end);
 	SystemTimeToFileTime(&initial, &finitial);
 	SystemTimeToFileTime(&end, &fend);
-	if (((finitial.dwHighDateTime - fend.dwHighDateTime) > 10) || ((finitial.dwLowDateTime - fend.dwLowDateTime) > 10))
+	if (((fend.dwHighDateTime - finitial.dwHighDateTime) > 10) || ((fend.dwLowDateTime - finitial.dwLowDateTime) > 10))
 		printf("Debugger detected\n");
 	else
 		printf("Debugger not detected\n");
@@ -624,7 +624,7 @@ void sGetLocalTime() {
 	GetLocalTime(&end);
 	SystemTimeToFileTime(&initial, &finitial);
 	SystemTimeToFileTime(&end, &fend);
-	if (((finitial.dwHighDateTime - fend.dwHighDateTime) > 10) || ((finitial.dwLowDateTime - fend.dwLowDateTime) > 10))
+	if (((fend.dwHighDateTime - finitial.dwHighDateTime) > 10) || ((fend.dwLowDateTime - finitial.dwLowDateTime) > 10))
 		printf("Debugger detected\n");
 	else
 		printf("Debugger not detected\n");
@@ -641,7 +641,7 @@ void sQueryPerformanceCounter() {
 		if (QueryPerformanceCounter(&end)) {
 			printf("\ninitial.LowPart %02d \n" , initial.LowPart);
 			printf("\nend.LowPart %02d \n" , end.LowPart);
-			if ((initial.QuadPart - end.QuadPart) > 0x10)
+			if ((end.QuadPart - initial.QuadPart) > 0x10)
 				printf("Debugger detected\n");
 			else
 				printf("Debugger not detected\n");
@@ -750,7 +750,7 @@ int _tmain(int argc, _TCHAR* argv[])
 	printf("19 - 3.19 FindWindow\n");
 	printf("20 - 3.20 SuspendThread\n");
 	printf("21 - 3.23 UnhandledExceptionFilter\n");
-	printf("22 - 3.24 Guard Pages\n");
+	//printf("22 - 3.24 Guard Pages\n");
 	printf("23 - 3.25 Execution Timing - GetTickCount()\n");
 	printf("24 - 3.25 Execution Timing - timeGetTime\n");
 	printf("25 - 3.25 Execution Timing - GetSystemTime()\n");
@@ -825,9 +825,9 @@ int _tmain(int argc, _TCHAR* argv[])
 	case 21:
 		fSetUnhandledExceptionFilter();
 		break;
-	case 22:
-		ret = psVirtuaAlloc_VirtualProtect();
-		break;
+	// case 22:
+	// 	ret = psVirtuaAlloc_VirtualProtect();
+	// 	break;
 	case 23:
 		sGetTickCount();
 		break;


### PR DESCRIPTION
Thank you for your useful samples.
I found the following problems of your samples.
- softice.ASM does not set a exception handler. 
  And, Flat Assembler generates "icebp" from "int1" mnemonic.
- Execution Timing tests calculate "initial - end".
- Guard Pages test does not jump to the allocated pages.

I fixed softice.ASM and Execution Timing tests.
And, I reimplemented Guard Pages test using assembly language.
If you please, pull my commit.
