### PR TITLE
if condition fix - technique 3.5

### DIFF
--- a/Csrc/fcall_examples/fcall_examples/fcall_examples.cpp
+++ b/Csrc/fcall_examples/fcall_examples/fcall_examples.cpp
@@ -96,7 +96,7 @@ void pProcessDebugPort() {
 
 	proc = GetCurrentProcess();
 	ntStatus = NtQueryInformationProcess(proc,ProcessDebugPort,&debugport,sizeof(debugport),NULL);
-	if (ntStatus != 0)
+	if (debugport != 0)
 		printf("Debugger detected\n");
 	else
 		printf("Debugger not detected\n");


### PR DESCRIPTION
For this technique (3.5), the ProcessInformation (debugport) parameter is checked and not the value returned from NtQueryInformationProcess.
